### PR TITLE
Fix bottom bulk action dropdown

### DIFF
--- a/wp-signups/includes/functions/admin.php
+++ b/wp-signups/includes/functions/admin.php
@@ -170,12 +170,11 @@ function wp_signups_handle_actions() {
 	// Bail if no action
 	if ( ! empty( $_REQUEST['action'] ) && empty(  $_REQUEST['bulk_action2'] ) ) {
 		$request_action = $_REQUEST['action'];
-	} elseif ( ! empty( $_REQUEST['bulk_action'] ) ) {
-		$request_action = $_REQUEST['bulk_action'];
-	} elseif ( ! empty( $_REQUEST['bulk_action2'] ) ) {
-		$request_action = $_REQUEST['bulk_action2'];
 	} else {
-		return;
+		$request_action = $this->current_action();
+		if ( $request_action === false ) {
+			return;
+		}
 	}
 
 	// Get action


### PR DESCRIPTION
Currently if you choose a bulk action from the bottom dropdown, or even no bulk action at all, you get "An error has occurred" on submit, because the top dropdown is initially set to value -1 and the check is empty().
See https://github.com/stuttter/wp-user-signups/blob/master/wp-signups/includes/classes/class-wp-signups-list-table.php#L200
Choosing the parameter is already handled by current_action.