### PR TITLE
Allow composer/installers v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "type": "wordpress-plugin",
   "require": {
     "php": ">=5.2",
-    "composer/installers": "^1.0"
+    "composer/installers": "^1.0 || ^2.0"
   },
   "license": "GPL-2.0-or-later",
   "authors": [


### PR DESCRIPTION
Widens the `composer/installers` constraint from `^1.0` to `^1.0 || ^2.0`. 

Discussed in #14 

**Why:** installers 1.x is unmaintained (last `1.x` commit March 2022; current release v2.3.0) and emits implicit-nullable deprecations on PHP 8.4, fixed in v2.0.0. Composer resolves one version of `composer/installers` per project, so a single `^1.0` pin holds back the whole dependency tree.

**Why widen rather than replace:** this plugin declares `php: >=5.2` and installers v2 requires `^7.2 || ^8.0`. Leaving `^1.0` in place means older-PHP installs still resolve v1 and nothing changes for existing users.

**Risk:** none that I can see. The dependency only exists so `type: wordpress-plugin` installs to `wp-content/plugins`, and `WordPressInstaller` is identical between v1 and v2 apart from a docblock — same `plugin`, `theme`, `muplugin`, `dropin` paths. v2 also still supports `composer-plugin-api: ^1.0 || ^2.0`, so Composer 1.x users are unaffected.

**Release:** `master` already reads 5.0.3 in the plugin header, `readme.txt` and `CHANGELOG.md`, but the latest tag is `5.0.2`. Downstream pins `^5.0.2`, so this only reaches consumers once a tag is cut — would be great to get this into 5.0.3.